### PR TITLE
Add accessible variant tabs to home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,6 +24,33 @@ if (supabase) {
 // Get guides
 const connectGuide = await getEntry("guides", "guide-connect-supabase");
 const fetchDataGuide = await getEntry("guides", "guide-fetch-data");
+
+const variantPanels = [
+  {
+    triggerId: "variant-trigger-setup",
+    panelId: "variant-panel-setup",
+    label: "Setup",
+    heading: "Set up Supabase",
+    description:
+      "Follow the Supabase connection guide to finish provisioning your project's database tables and connection credentials.",
+  },
+  {
+    triggerId: "variant-trigger-data",
+    panelId: "variant-panel-data",
+    label: "Fetch Data",
+    heading: "Fetch framework data",
+    description:
+      "Use the example query to pull framework information from Supabase, then customize the table columns to fit your own schema.",
+  },
+  {
+    triggerId: "variant-trigger-deploy",
+    panelId: "variant-panel-deploy",
+    label: "Deploy",
+    heading: "Deploy your app",
+    description:
+      "Once everything looks good locally, deploy to your preferred host and bring your Supabase environment variables along.",
+  },
+];
 ---
 
 <Layout title="Web Frameworks">
@@ -68,4 +95,130 @@ const fetchDataGuide = await getEntry("guides", "guide-fetch-data");
       </>
     )
   }
+  <section
+    aria-labelledby="variant-section-heading"
+    class="mt-16 rounded-lg border border-slate-200 bg-white p-6 shadow-sm"
+  >
+    <h2 id="variant-section-heading" class="text-2xl font-semibold">
+      Starter project variants
+    </h2>
+    <p class="mt-2 text-slate-600">
+      Explore the main workflows for this Astro + Supabase starter and choose the
+      panel that matches the step you're working on.
+    </p>
+    <div
+      class="mt-6 flex flex-wrap gap-2"
+      role="tablist"
+      aria-labelledby="variant-section-heading"
+    >
+      {variantPanels.map((panel, index) => (
+        <button
+          id={panel.triggerId}
+          type="button"
+          class={`rounded-md border px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring focus-visible:ring-slate-500 ${
+            index === 0
+              ? "border-slate-900 bg-slate-900 text-white"
+              : "border-slate-200 bg-white text-slate-900 hover:border-slate-300 hover:bg-slate-50"
+          }`}
+          role="tab"
+          aria-selected={index === 0 ? "true" : "false"}
+          aria-controls={panel.panelId}
+          data-variant-trigger
+          tabindex={index === 0 ? 0 : -1}
+        >
+          {panel.label}
+        </button>
+      ))}
+    </div>
+    <div class="mt-8 space-y-6">
+      {variantPanels.map((panel, index) => (
+        <div
+          id={panel.panelId}
+          role="tabpanel"
+          aria-labelledby={panel.triggerId}
+          data-variant-panel
+          class="rounded-md border border-slate-200 bg-slate-50 p-6"
+          hidden={index !== 0}
+        >
+          <h3 class="text-xl font-semibold text-slate-900">{panel.heading}</h3>
+          <p class="mt-3 text-slate-700">{panel.description}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+  <script>
+    // @ts-nocheck
+    const variantTriggerButtons = Array.from(
+      document.querySelectorAll('[data-variant-trigger]')
+    );
+    const variantPanelElements = Array.from(
+      document.querySelectorAll('[data-variant-panel]')
+    );
+
+    /**
+     * @param {HTMLButtonElement} trigger
+     * @returns {void}
+     */
+    function activatePanel(trigger) {
+      if (!(trigger instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      const targetPanelId = trigger.getAttribute('aria-controls');
+      const targetPanel = variantPanelElements.find(
+        (panel) => panel instanceof HTMLElement && panel.id === targetPanelId
+      );
+
+      if (!(targetPanel instanceof HTMLElement)) {
+        return;
+      }
+
+      variantTriggerButtons.forEach((btn) => {
+        if (btn instanceof HTMLButtonElement) {
+          const isActive = btn === trigger;
+          btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          btn.setAttribute('tabindex', isActive ? '0' : '-1');
+        }
+      });
+
+      variantPanelElements.forEach((panel) => {
+        if (panel instanceof HTMLElement) {
+          const shouldShow = panel === targetPanel;
+          panel.toggleAttribute('hidden', !shouldShow);
+        }
+      });
+    }
+
+    variantTriggerButtons.forEach((trigger) => {
+      trigger.addEventListener('click', () => {
+        if (trigger instanceof HTMLButtonElement) {
+          activatePanel(trigger);
+        }
+      });
+      trigger.addEventListener('keydown', (event) => {
+        if (!(trigger instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        if (!(event instanceof KeyboardEvent)) {
+          return;
+        }
+
+        if (event.key === ' ' || event.key === 'Enter') {
+          event.preventDefault();
+          activatePanel(trigger);
+        }
+      });
+    });
+
+    const initiallySelected = variantTriggerButtons.find(
+      (trigger) =>
+        trigger instanceof HTMLButtonElement &&
+        trigger.getAttribute('aria-selected') === 'true'
+    );
+
+    if (initiallySelected instanceof HTMLButtonElement) {
+      activatePanel(initiallySelected);
+    }
+  </script>
 </Layout>


### PR DESCRIPTION
## Summary
- add a starter variants tab section to the homepage with labelled triggers and tabpanels
- connect each trigger and panel with ids and aria attributes for better accessibility
- update the inline script to toggle aria-selected, manage tabindex, and leave aria-pressed unused

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f1cab692c4832987e7658d836ca208